### PR TITLE
Fix case bug that in require

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var spawn = require('child_process').spawn;
 var debug = require('debug')('sql2csv')
-require('String.prototype.endswith')
+require('string.prototype.endswith')
 
 var sql2csv = {
   guess: function (db) {


### PR DESCRIPTION
In two differents servers (on local server in mac and an ubuntu server) the case in require('String.prototype.endswith') returns the following error:

`Error: Cannot find module 'String.prototype.endswith'`

Changing the case fix the problem